### PR TITLE
Add Express webhook server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "socket.io-client": "^4.7.5"
+    "socket.io-client": "^4.7.5",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,45 @@
+import express from 'express';
+import cors from 'cors';
+import http from 'http';
+import { Server } from 'socket.io';
+import crypto from 'crypto';
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*'
+  }
+});
+
+app.use(cors());
+app.use(express.json({
+  verify: (req, res, buf) => {
+    req.rawBody = buf;
+  }
+}));
+
+app.post('/api/webhook', (req, res) => {
+  const secret = process.env.SHOPIFY_SHARED_SECRET || '';
+  const hmacHeader = req.get('X-Shopify-Hmac-SHA256') || '';
+  const digest = crypto
+    .createHmac('sha256', secret)
+    .update(req.rawBody)
+    .digest('base64');
+
+  const valid =
+    hmacHeader &&
+    crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(hmacHeader));
+
+  if (valid) {
+    io.emit('newWebhookData', req.body);
+    res.status(200).send({ received: true });
+  } else {
+    res.status(401).send('Invalid webhook signature');
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create `server/` folder with Express and Socket.IO setup
- verify `X-Shopify-Hmac-SHA256` in `/api/webhook`
- emit `newWebhookData` to Socket.IO clients when webhook is valid
- add server dependencies and `npm run server` script

## Testing
- `npm install`
- `npm run build`
- `npm run server` (manual run)

------
https://chatgpt.com/codex/tasks/task_e_684e4cd72d2083238c1ace58c4a82a0b