### PR TITLE
Add Vercel config and build step

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -4,7 +4,7 @@ import { CapturedResponseItem } from './types';
 export const APP_TITLE = "Webhook";
 export const APP_SUBTITLE = "Incoming Webhook";
 export const CALLBACK_URL_PATH = "/api/webhook"; // Actual path on your backend
-export const DEFAULT_BACKEND_URL = "http://localhost:3001"; // Default backend URL
+export const DEFAULT_BACKEND_URL = "https://your-backend.vercel.app"; // Default backend URL
 
 export const DEFAULT_WEBHOOK_NAME = "Untitled Webhook";
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "vercel-build": "npm run build && tsc",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "functions": { "api/**/*.ts": { "runtime": "nodejs18.x" } }
+}


### PR DESCRIPTION
## Summary
- add basic `vercel.json`
- add a `vercel-build` script that runs `npm run build && tsc`
- set default backend URL to the deployed endpoint

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4cda3930832396633a8f93936ca1