### PR TITLE
Fix package.json syntax for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-
+    "build": "vite build"
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- remove the trailing comma in the `build` script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e4ddca0908323be262e2c91b16ef9